### PR TITLE
feat: use short git commit hashes - by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ httpLogLevel | configures the http logging while using the Octopus API | `HttpLo
 issueTrackerName | When parsing issues the target issue tracker name is needed. Currently only `Jira` supported | **optional/none**
 parseCommitsForJiraIssues | Enable Jira Issue parsing. This needs the changelog generation enabled to parse the commits there. | **optional/none**
 jiraBaseBrowseUrl | For proper Jira URLs we need the base URL, something like `https://testric.atlassian.net/browse/`. | **optional/none**
+useShortCommitHashes | Use short (7 char) commit hashes. | true
 
 `generateChangelogSinceLastTag` extracts all commits between the HEAD and the last tag. 
 If no tag is found, the first commit in the history tree is used instead.

--- a/src/main/kotlin/com/liftric/octopusdeploy/OctopusDeployExtension.kt
+++ b/src/main/kotlin/com/liftric/octopusdeploy/OctopusDeployExtension.kt
@@ -107,6 +107,13 @@ open class OctopusDeployExtension(project: Project) {
     val jiraBaseBrowseUrl: Property<String> = project.objects.property()
 
     /**
+     * Use short (7 char) commit hashes. Default is [true]
+     */
+    @Input
+    @Optional
+    val useShortCommitHashes: Property<Boolean> = project.objects.property()
+
+    /**
      * Default `buildInformationAddition` implementation adding context from the CI environment for Gitlab CI. Also sets `commitLinkBaseUrl`.
      */
     fun gitlab(): Unit {

--- a/src/main/kotlin/com/liftric/octopusdeploy/OctopusDeployPlugin.kt
+++ b/src/main/kotlin/com/liftric/octopusdeploy/OctopusDeployPlugin.kt
@@ -30,6 +30,7 @@ class OctopusDeployPlugin : Plugin<Project> {
             project.tasks.create("commitsSinceLastTag", CommitsSinceLastTagTask::class.java).apply {
                 dependsOn(getFirstCommitHashTask, getPreviousTagTask)
                 project.afterEvaluate {
+                    useShortCommitHashes.set(extension.useShortCommitHashes)
                     workingDir = extension.gitRoot
                     commitLinkBaseUrl = extension.commitLinkBaseUrl
                 }


### PR DESCRIPTION
Using the first 7 chars is considered save, so let's adapt it in our plugin aswell. 

Old approach using the full commit hashes can be enabled using the new useShortCommitHashes property.